### PR TITLE
Added __repr__ for _WavyProfileEndpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 ### Added
 - Added utility for parsing wavy.fm date strings (RFC3339): `wavyfm.util.datetime_from_string` (GH-5)
+- Added __repr__ to `wavfym.users._WavyProfileEndpoints`
 
 ## [1.0.1] - 2021-01-25
 ### Fixes

--- a/wavyfm/users.py
+++ b/wavyfm/users.py
@@ -10,6 +10,9 @@ class _WavyProfileEndpoints:
         self._client = client
         self._uri = user_uri
 
+    def __repr__(self):
+        return f"<WavyProfileEndpoints '{self._uri}'>"
+
     def get_profile(self) -> Dict:
         """
         Retrieve this user's profile.


### PR DESCRIPTION
When developing with the library previously you had to peek into hidden properties or make HTTP to check which user a _WavyUserEndpoint object referred to, this helps disambiguate in those situations.

Currently objects look like this:
```python3
>>> users = [wavy.users.by_username(username) for username in usernames]
>>> users
[<wavyfm.users._WavyProfileEndpoints object at 0x106932f70>, 
 <wavyfm.users._WavyProfileEndpoints object at 0x106934070>,
 <wavyfm.users._WavyProfileEndpoints object at 0x107586a90>, 
 <wavyfm.users._WavyProfileEndpoints object at 0x107586a30>]
```

My proposed change would look like this:
```python3
>>> users
[<WavyProfileEndpoints 'wavyfm:user:username:jake'>, 
 <WavyProfileEndpoints 'wavyfm:user:username:christian'>, 
 <WavyProfileEndpoints 'wavyfm:user:username:chipmunkey'>, 
 <WavyProfileEndpoints 'wavyfm:user:username:aram'>]
```

This will help developers while prototyping and debugging code using this library.